### PR TITLE
Update Dart SDK Version Constraint for Flutter 3.10.0 Compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage: https://github.com/sqids/sqids-dart
 
 environment:
-    sdk: ">=3.2.0 <4.0.0"
+    sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
 


### PR DESCRIPTION
Hello sqids team,

I appreciate your efforts in maintaining the sqids and am excited to contribute. I've noticed that the current Dart SDK constraints (>=3.2.0 <4.0.0) exclude Flutter 3.10.0, which uses Dart 3.0.0. To broaden compatibility, I propose updating the pubspec.yaml to >=3.0.0 <4.0.0. This change:

- Supports Flutter 3.10.0 projects.
- Maintains compatibility with future Dart versions up to 4.0.0.

I've tested this update, confirming that it passes all existing tests and maintains expected functionality. This minor adjustment could significantly enhance the library's usability and adoption.

Looking forward to your feedback!

### References
- https://flutter-ko.dev/development/tools/sdk/releases